### PR TITLE
#49 Fix: Add Mongoose as a direct dependency

### DIFF
--- a/hello-world/package.json
+++ b/hello-world/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "lodash": "4.x.x",
+    "mongoose": "4.x",
     "strapi": "3.0.0-alpha.12",
     "strapi-mongoose": "3.0.0-alpha.12"
   },


### PR DESCRIPTION
Simple fix for #49.

Save mongoose as a direct dependency to the package.json so that a user can just run `npm install` and then get right on with strapi start without having to debug the missing dependency error message.

Tested by removing `node_modules`, reinstalling with `npm install` and running `strapi start` directly afterward.