### PR TITLE
Microsoft is changing app registration link

### DIFF
--- a/login-react/doc/microsoft_setup.md
+++ b/login-react/doc/microsoft_setup.md
@@ -1,6 +1,6 @@
 # Microsoft Setup
 
-Go to the [Microsoft Developers](https://apps.dev.microsoft.com/) site and create an app, leaving the **Guided Setup** box unchecked.
+Go to the [Azure Applications List](https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade) site and create an app, leaving the **Guided Setup** box unchecked.
 - Under **Platforms**, click `Add Platform` and select `Web`
 - In the **Redirect URLs** field, put `http://localhost:1337/connect/microsoft/callback`
 - Click `Save` at the bottom of the screen


### PR DESCRIPTION
As of "May 2019" the link for registering Microsoft Login Applications is changing and the old link will no longer work. If you click on the old link and try to add an application you get a popup telling you the link will stop working soon and that you should use the Azure Portal link to register applications now.