### PR TITLE
jekyll-strapi 0.1.1 was yanked. updated to 0.1.2

### DIFF
--- a/jekyll-strapi-tutorial/blog/Gemfile.lock
+++ b/jekyll-strapi-tutorial/blog/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       sass (~> 3.4)
     jekyll-seo-tag (2.4.0)
       jekyll (~> 3.3)
-    jekyll-strapi (0.1.1)
+    jekyll-strapi (0.1.2)
     jekyll-watch (2.0.0)
       listen (~> 3.0)
     kramdown (1.16.2)


### PR DESCRIPTION
Ran into an issue trying to bundle install because jekyll-strapi 0.1.1 got yanked which caused the install to error. This updated version in the lock file fixes it. There's probably a more correct way to solve it but I'm fairly ignorant when it comes to ruby.  🙈