### PR TITLE
Remove dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 ## Examples
 
-- **[Hello World](./hello-world) -** *Basic app to say hello to everyone* <br />
-   `routes` `controllers` `i18n`
 - **[Cheesecakes](./cheesecakes) -** *e-commerce application* <br />
    `routes` `controllers` `models` `services` `relations` `auth`
 - **[Gatsby Strapi Tutorial](./gatsby-strapi-tutorial) -** *Source code of the tutorial "[Building a static blog using Gatsby and Strapi](https://blog.strapi.io/building-a-static-website-using-gatsby-and-strapi)".* <br />


### PR DESCRIPTION
Removes the dead link to the Hello World example which was removed a while ago.