### PR TITLE
Add CAS as provider

### DIFF
--- a/login-react/src/pages/Home.js
+++ b/login-react/src/pages/Home.js
@@ -11,6 +11,7 @@ const providersNames = [
   'twitch',
   'instagram',
   'vk',
+  'cas'
 ];
 
 const LoginButton = (props) => <a href={`${backendUrl}/connect/${props.providerName}`}>


### PR DESCRIPTION
Signed-off-by: Hal Deadman <hal.deadman@gmail.com>

![image](https://user-images.githubusercontent.com/1556777/95926850-48ec6800-0d8b-11eb-9b1c-d4a65d65ff54.png)

When I pointed this app at my strapi 3.2.3 app with CAS provider in an extension layer and configured to point at my dev lab CAS server configured with OIDC support and a service definition that allows logins from service running at http://localhost:1337, I was able click `Connect to cas` button got redirected to CAS and got JWT token seen in screen shot.  

![image](https://user-images.githubusercontent.com/1556777/95927174-1000c300-0d8c-11eb-9f51-43c0e4c54acb.png)
